### PR TITLE
Fix: 원본 URL의 전송 방법 수정

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -143,9 +143,13 @@
         }
 
         // 단축 URL 생성 요청 및 처리
-        var queryUrl="/short?url="+inputUrl;
+        var queryUrl="/short"
         fetch(queryUrl,{
-            method: "POST"
+            method: "POST",
+            headers:{
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({ originalUrl : inputUrl })
         })
             .then(response => {
                 if(!response.ok){


### PR DESCRIPTION
#12 문제 수정

원본 URL 내 URL에서 사용되는 특수 문자가 있는 경우,
전송될 때, 본 요청 URL에 포함 처리되는 문제로 인해, 원본 URL 값이 손상되는 문제 발견 및 수정

기존 : URL 파라미터의 원본 URL 값을 대입하여 전송
수정 : Request Body에 원본 URL 값을 대입하여 전송