### PR TITLE
Feat: 단축 URL로 접속 시, 클라이언트 정보 저장 기능 구현

### DIFF
--- a/src/main/java/be/gyu/urlShortener/controller/MainController.java
+++ b/src/main/java/be/gyu/urlShortener/controller/MainController.java
@@ -57,9 +57,13 @@ public class MainController {
      * @param response Re-Direct 응답 처리를 위한 매개변수
      */
     @GetMapping("/{shortUrl}")
-    public void getShortUrl(@PathVariable(name="shortUrl") String shortUrl, HttpServletResponse response){
+    public void getShortUrl(@PathVariable(name="shortUrl") String shortUrl, HttpServletRequest request, HttpServletResponse response){
+        // 접속 정보들 추출
+        String userAgent=request.getHeader("User-Agent");
+        String userIpAddr=request.getRemoteAddr();
+
         // 단축 URL을 통해, 원본 URL을 가져옴.
-        String originalUrl=mainService.getOriginalUrl(shortUrl);
+        String originalUrl=mainService.getOriginalUrl(shortUrl,userAgent,userIpAddr);
         // 가져온 원본 URL 값을 적잘한 URL이 될 수 있도록 Re-Direct하기 전에 URL-Encoding
         String encodeUrl=UriComponentsBuilder.fromUriString(originalUrl).build().encode().toUriString();
         // Re-Direct 상태 코드 설정

--- a/src/main/java/be/gyu/urlShortener/entity/ClickStat.java
+++ b/src/main/java/be/gyu/urlShortener/entity/ClickStat.java
@@ -1,0 +1,28 @@
+package be.gyu.urlShortener.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClickStat {
+    @Id
+    private Long clickStatId;
+    @ManyToOne
+    @JoinColumn(name="url_map_id")
+    private UrlMap urlMap;
+    private LocalDateTime clickStatClickedAt;
+    private String clickStatUserAgent;
+    private String clickStatIpAddr;
+}

--- a/src/main/java/be/gyu/urlShortener/repository/ClickStatRepository.java
+++ b/src/main/java/be/gyu/urlShortener/repository/ClickStatRepository.java
@@ -1,0 +1,11 @@
+package be.gyu.urlShortener.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import be.gyu.urlShortener.entity.ClickStat;
+
+@Repository
+public interface ClickStatRepository extends JpaRepository<ClickStat,Long>{
+    
+}


### PR DESCRIPTION
#18 연계 구현

단축 URL 별 접속 통계 기능 구현을 위해,
- 단축 URL로 클라이언트(사용자)가 접속할 경우, 해당 사용자의 User-Agent 값, IP 주소 값을 DB에 저장
- 추후, 단축 URL의 접속 통계 기능에서 활용
