### PR TITLE
Fix: 단축 URL 접속 정보 Entity의 ID 값 누락 수정

### DIFF
--- a/src/main/java/be/gyu/urlShortener/entity/ClickStat.java
+++ b/src/main/java/be/gyu/urlShortener/entity/ClickStat.java
@@ -3,6 +3,8 @@ package be.gyu.urlShortener.entity;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -18,6 +20,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ClickStat {
     @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
     private Long clickStatId;
     @ManyToOne
     @JoinColumn(name="url_map_id")


### PR DESCRIPTION
ID 값의 자동 생성 값 Annotation(GenerateValue)을 설정하지 않아 발생하는 오류 수정
